### PR TITLE
Remove obsolete QRCodeActivity hooks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 27
-        versionName "6.0"
+        versionName "6.13"
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/suraj/waext/ExtModule.java
+++ b/app/src/main/java/com/suraj/waext/ExtModule.java
@@ -879,12 +879,12 @@ public class ExtModule implements IXposedHookLoadPackage, IXposedHookZygoteInit,
             @Override
             protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
                 super.beforeHookedMethod(param);
-/*
+
                 String number = param.args[0].toString().split("@")[0];
 
                 if(blockContacts && blockContactsSet.contains(number))
                     param.setResult(null);
-*/
+
             }
 
             @Override

--- a/app/src/main/java/com/suraj/waext/ExtModule.java
+++ b/app/src/main/java/com/suraj/waext/ExtModule.java
@@ -633,13 +633,6 @@ public class ExtModule implements IXposedHookLoadPackage, IXposedHookZygoteInit,
                         }
                         break;
 
-                    case "com.whatsapp.qrcode.QrCodeActivity":
-                        if (!lockWAWeb)
-                            return;
-
-                        startLockActivity(param.thisObject);
-                        break;
-
                     case "com.whatsapp.ArchivedConversationsActivity":
                         if (!lockArchived)
                             return;
@@ -653,19 +646,6 @@ public class ExtModule implements IXposedHookLoadPackage, IXposedHookZygoteInit,
                     thread.interrupt();
                 }
 
-            }
-        });
-
-        XposedHelpers.findAndHookMethod("com.whatsapp.qrcode.QrCodeActivity", loadPackageParam.classLoader, "onCreate", Bundle.class, new XC_MethodHook() {
-            @Override
-            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
-                super.beforeHookedMethod(param);
-
-                if (!lockWAWeb)
-                    return;
-
-                firstTime = true;
-                showLockScreen = true;
             }
         });
 

--- a/app/src/main/java/com/suraj/waext/MainActivity.java
+++ b/app/src/main/java/com/suraj/waext/MainActivity.java
@@ -166,7 +166,6 @@ public class MainActivity extends AppCompatActivity {
         );
 
         setUpProtectedCheckBox((CheckBox) findViewById(R.id.chkboxHideNotifs), "hideNotifs", false, "", false, "");
-        setUpProtectedCheckBox((CheckBox) findViewById(R.id.chkboxLockWAWeb), "lockWAWeb", false, "", false, "");
         setUpProtectedCheckBox((CheckBox) findViewById(R.id.chkboxLockArchived), "lockArchived", false, "", false, "");
     }
 


### PR DESCRIPTION
Remove the obsolote hooks and "Lock Whatsapp Web" checkboxes from GUI.
However since the hooks is removed, I'd assume the Lock function is broken, more logs is needed.